### PR TITLE
API should not be mapStateToProps, trying connectRex

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ export function doIncData() {
 Selector:
 
 ```tsx
-@mapStateToProps((store: IGlobalStore) => ({ data: store.data }))
+@connectRex((store: IGlobalStore) => ({ data: store.data }))
 export default class Inside extends React.PureComponent<IProps, IState> {
   render() {
-    return <div/>;
+    return <div />;
   }
 }
 ```

--- a/rex/rex.tsx
+++ b/rex/rex.tsx
@@ -111,7 +111,7 @@ class RexDataLayer extends React.Component<IRexDataLayerProps, IRexDataLayerStat
   };
 }
 
-export function mapStateToProps<T>(selector: (s: T, ownProps?: any) => any): any {
+export function connectRex<T>(selector: (s: T, ownProps?: any) => any): any {
   return (Target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
     return class RexContainer extends React.Component {
       render() {

--- a/src/pages/branch-data.tsx
+++ b/src/pages/branch-data.tsx
@@ -3,7 +3,7 @@ import { css, cx } from "emotion";
 import produce from "immer";
 import randomcolor from "randomcolor";
 
-import { mapStateToProps } from "rex";
+import { connectRex } from "rex";
 import { IGlobalStore } from "models/global";
 import { doIncBranch } from "controllers/data";
 import { randomBg } from "util/color";
@@ -15,7 +15,7 @@ interface IProps {
 
 interface IState {}
 
-@mapStateToProps((store: IGlobalStore) => ({ data: store.branchData }))
+@connectRex((store: IGlobalStore) => ({ data: store.branchData }))
 export default class BranchData extends React.PureComponent<IProps, IState> {
   constructor(props) {
     super(props);

--- a/src/pages/inside.tsx
+++ b/src/pages/inside.tsx
@@ -3,7 +3,7 @@ import { css, cx } from "emotion";
 import produce from "immer";
 import randomcolor from "randomcolor";
 
-import { mapStateToProps } from "rex";
+import { connectRex } from "rex";
 import { IGlobalStore } from "models/global";
 import { doIncData } from "controllers/data";
 import { randomBg } from "util/color";
@@ -15,7 +15,7 @@ interface IProps {
 
 interface IState {}
 
-@mapStateToProps((store: IGlobalStore, ownProps: IProps) => {
+@connectRex((store: IGlobalStore, ownProps: IProps) => {
   console.log("ownProps", ownProps);
   return { data: store.data };
 })


### PR DESCRIPTION
Redux 里面用的 `connect`, 可能用 `connect` 比较好? `connectRex` 考虑是项目代码共存, 用不同的方法名称更加容易区分.
