### PR TITLE
make store type exported; bump 0.1.1-a1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rex",
-  "version": "0.1.0",
+  "version": "0.1.1-a1",
   "description": "Data wrapper",
   "main": "./lib/rex.js",
   "types": "./lib/rex.d.ts",

--- a/rex/rex.tsx
+++ b/rex/rex.tsx
@@ -8,7 +8,7 @@ function devPoint(...args: any[]) {
 
 // Rex Store Implementation
 
-interface IRexStore<T> {
+export interface IRexStore<T> {
   getState: () => T;
   subscribe: (f: (store: T) => void) => { unsubscribe: () => void };
   update: (f: (store: T) => void) => void;


### PR DESCRIPTION
Trying to fix an error:

```
Exported variable 'globalStore' has or is using name 'IRexStore' from external module "/Users/chen/work/shopfloor-app/node_modules/@jimengio/rex/lib/rex" but cannot be named.ts(4023)
```